### PR TITLE
Optimize is_min_level() function

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,41 @@
+#![feature(test)]
+
+extern crate min_max_heap;
+extern crate test;
+
+use min_max_heap::MinMaxHeap;
+use test::Bencher;
+
+#[bench]
+fn push_seq(b: &mut Bencher) {
+    b.iter(|| {
+        let n = 1000;
+        let mut heap = MinMaxHeap::with_capacity(n);
+        for i in 0..n {
+            heap.push(i);
+        }
+    });
+}
+
+#[bench]
+fn pop_max_seq(b: &mut Bencher) {
+    b.iter(|| {
+        let n = 1000;
+        let mut heap: MinMaxHeap<_> = (0..n).collect();
+        for _ in 0..n {
+            heap.pop_max();
+        }
+    });
+}
+
+#[bench]
+fn pop_min_seq(b: &mut Bencher) {
+    b.iter(|| {
+        let n = 1000;
+        let mut heap: MinMaxHeap<_> = (0..n).collect();
+        for _ in 0..n {
+            heap.pop_min();
+        }
+    });
+}
+

--- a/src/index.rs
+++ b/src/index.rs
@@ -46,15 +46,8 @@ impl HeapIndex for usize {
     }
 
     #[inline]
-    fn is_min_level(mut self) -> bool {
-        let mut result = true;
-
-        while self > 0 {
-            self = self.parent();
-            result = !result;
-        }
-
-        result
+    fn is_min_level(self) -> bool {
+        (self + 1).leading_zeros() % 2 == 1
     }
 }
 


### PR DESCRIPTION
This adds a couple of simple push/pop_min/pop_max benchmarks and applies a minor optimization to the `is_min_level()` function. Benchmarks before/after:

```
Before:
test pop_max_seq ... bench:      53,099 ns/iter (+/- 2,666)
test pop_min_seq ... bench:      77,194 ns/iter (+/- 3,006)
test push_seq    ... bench:      13,041 ns/iter (+/- 326)

After:
test pop_max_seq ... bench:      50,055 ns/iter (+/- 2,839)
test pop_min_seq ... bench:      74,374 ns/iter (+/- 3,805)
test push_seq    ... bench:      10,139 ns/iter (+/- 237)
```