### PR TITLE
peek_*_mut

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.24.0
+  - 1.31.0
 
 # helpful for kcov
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog] and this project adheres to
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: http://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+- Methods `MinMaxHeap::peek_min_mut` and `MinMaxHeap::peek_max_mut`*.
+
+### Changed
+- Oldest supported rustc version is now 1.31.0.
+
 ## [1.2.2] - 2018-12-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ And add this to your crate root:
 extern crate min_max_heap;
 ```
 
-This crate supports Rust version 1.24.0 and later.
+This crate supports Rust version 1.31.0 and later.
 
 ## References
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,11 +850,11 @@ mod tests {
     #[test]
     fn peek_min_mut() {
         let mut h = MinMaxHeap::from(vec![2, 3, 4]);
-        *(h.peek_min_mut().unwrap()) = 1;
+        *h.peek_min_mut().unwrap() = 1;
         assert_eq!(Some(&1), h.peek_min());
         assert_eq!(Some(&4), h.peek_max());
 
-        *(h.peek_min_mut().unwrap()) = 8;
+        *h.peek_min_mut().unwrap() = 8;
         assert_eq!(Some(&3), h.peek_min());
         assert_eq!(Some(&8), h.peek_max());
 
@@ -866,11 +866,11 @@ mod tests {
     #[test]
     fn peek_max_mut() {
         let mut h = MinMaxHeap::from(vec![1, 2]);
-        *(h.peek_max_mut().unwrap()) = 3;
+        *h.peek_max_mut().unwrap() = 3;
         assert_eq!(Some(&1), h.peek_min());
         assert_eq!(Some(&3), h.peek_max());
 
-        *(h.peek_max_mut().unwrap()) = 0;
+        *h.peek_max_mut().unwrap() = 0;
         assert_eq!(Some(&0), h.peek_min());
         assert_eq!(Some(&1), h.peek_max());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -710,7 +710,7 @@ impl<T: Ord> Drop for PeekMaxMut<'_, T> {
 impl<T: Ord> Deref for PeekMaxMut<'_, T> {
     type Target = T;
     fn deref(&self) -> &T {
-        debug_assert!(!self.heap.is_empty());
+        debug_assert!(self.max_index < self.heap.len());
         // SAFE: PeekMaxMut is only instantiated for non-empty heaps
         unsafe { self.heap.0.get_unchecked(self.max_index) }
     }
@@ -718,7 +718,7 @@ impl<T: Ord> Deref for PeekMaxMut<'_, T> {
 
 impl<T: Ord> DerefMut for PeekMaxMut<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
-        debug_assert!(!self.heap.is_empty());
+        debug_assert!(self.max_index < self.heap.len());
         // SAFE: PeekMaxMut is only instantiated for non-empty heaps
         unsafe { self.heap.0.get_unchecked_mut(self.max_index) }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! extern crate min_max_heap;
 //! ```
 //!
-//! This crate supports Rust version 1.24.0 and later.
+//! This crate supports Rust version 1.31.0 and later.
 //!
 //! ## References
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -630,7 +630,7 @@ pub struct PeekMinMut<'a, T: 'a + Ord> {
 }
 
 impl<T: Ord + fmt::Debug> fmt::Debug for PeekMinMut<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("PeekMinMut")
          .field(&self.heap.0[0])
          .finish()
@@ -686,7 +686,7 @@ pub struct PeekMaxMut<'a, T: 'a + Ord> {
 }
 
 impl<T: Ord + fmt::Debug> fmt::Debug for PeekMaxMut<'_, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("PeekMaxMut")
          .field(&self.heap.0[self.max_index])
          .finish()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ impl<T: Ord> MinMaxHeap<T> {
     /// inconsistent state.
     ///
     /// *O*(1) for the peek; *O*(log *n*) when the reference is dropped.
-    pub fn peek_min_mut(&mut self) -> Option<PeekMinMut<'_, T>> {
+    pub fn peek_min_mut(&mut self) -> Option<PeekMinMut<T>> {
         if self.is_empty() {
             None
         } else {
@@ -144,7 +144,7 @@ impl<T: Ord> MinMaxHeap<T> {
     /// inconsistent state.
     ///
     /// *O*(1) for the peek; *O*(log *n*) when the reference is dropped.
-    pub fn peek_max_mut(&mut self) -> Option<PeekMaxMut<'_, T>> {
+    pub fn peek_max_mut(&mut self) -> Option<PeekMaxMut<T>> {
         self.find_max().map(move |i| PeekMaxMut {
             heap: self,
             max: i,
@@ -616,7 +616,7 @@ impl<'a, T: Ord + Clone + 'a> Extend<&'a T> for MinMaxHeap<T> {
     }
 }
 
-/// Structure wrapping a mutable reference to the minumum item on a
+/// Structure wrapping a mutable reference to the minimum item on a
 /// `MinMaxHeap`.
 ///
 /// This `struct` is created by the [`peek_min_mut`] method on [`MinMaxHeap`]. See


### PR DESCRIPTION
I'm using this library to implement k-way merge of multiple iterators. Essentially I push a tuple of each iterator and the next element it will yield into the heap, then the process of merging is to pull the max element off the heap, replace its current next element with its next next element, and return the previously-current one. In master this requires both a pop and a push, and correction of the heap after each. Neither replace_max nor push_pop_max quite get me what I want, because I'm going to be pushing the same element back onto the heap that I'm getting out, so I don't have it yet when I want to call replace.

The std::collections BinaryHeap has `peek_mut` which gets at this: you can get a mutable reference to the max item in the heap, and after that reference is dropped, the tree is re-heapified to account for any mutations that might change the item's rank. This PR ports that functionality to this library, as `peek_min_mut` and `peek_max_mut`.