### PR TITLE
Avoid panics in all heap functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ impl<T: Ord> MinMaxHeap<T> {
             return Some(element);
         }
 
-        // Heap was empty, so no reordering is neessary
+        // Heap was empty, so no reordering is necessary
         self.0.push(element);
         None
     }
@@ -331,7 +331,7 @@ impl<T: Ord> MinMaxHeap<T> {
             return Some(element);
         }
 
-        // Heap was empty, so no reordering is neessary
+        // Heap was empty, so no reordering is necessary
         self.0.push(element);
         None
     }
@@ -506,7 +506,7 @@ impl<T> MinMaxHeap<T> {
     /// Returns a draining iterator over the min-max-heap’s elements in
     /// descending (max-first) order.
     ///
-    /// *<<1) on creation, and *O*(log *n*) for each `next()` operation.
+    /// *O*(1) on creation, and *O*(log *n*) for each `next()` operation.
     pub fn drain_desc(&mut self) -> DrainDesc<T> {
         DrainDesc(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -798,12 +798,9 @@ impl<'a, T: Ord> Drop for PeekMaxMut<'a, T> {
             // SAFETY: `max_index` is a valid index in `heap`
             let mut hole = unsafe { Hole::new(&mut self.heap.0, self.max_index) };
 
-            if let Some(parent) = hole.get_parent() {
-                if hole.element() < parent {
-                    // SAFETY: element has a parent
-                    unsafe {
-                        hole.swap_with_parent();
-                    }
+            if let Some(mut parent) = hole.get_parent() {
+                if parent.hole_element() < parent.other_element() {
+                   parent.swap_with();
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,7 +714,7 @@ impl<'a, T: Ord + Clone + 'a> Extend<&'a T> for MinMaxHeap<T> {
 ///
 /// [`peek_min_mut`]: struct.MinMaxHeap.html#method.peek_min_mut
 /// [`MinMaxHeap`]: struct.MinMaxHeap.html
-pub struct PeekMinMut<'a, T: 'a + Ord> {
+pub struct PeekMinMut<'a, T: Ord> {
     heap: &'a mut MinMaxHeap<T>,
     sift: bool,
 }
@@ -722,7 +722,7 @@ pub struct PeekMinMut<'a, T: 'a + Ord> {
 impl<T: Ord + fmt::Debug> fmt::Debug for PeekMinMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("PeekMinMut")
-         .field(&self.heap.0[0])
+         .field(&**self)
          .finish()
     }
 }
@@ -773,7 +773,7 @@ impl<'a, T: Ord> PeekMinMut<'a, T> {
 ///
 /// [`peek_max_mut`]: struct.MinMaxHeap.html#method.peek_max_mut
 /// [`MinMaxHeap`]: struct.MinMaxHeap.html
-pub struct PeekMaxMut<'a, T: 'a + Ord> {
+pub struct PeekMaxMut<'a, T: Ord> {
     heap: &'a mut MinMaxHeap<T>,
     max_index: usize,
     sift: bool,
@@ -782,7 +782,7 @@ pub struct PeekMaxMut<'a, T: 'a + Ord> {
 impl<T: Ord + fmt::Debug> fmt::Debug for PeekMaxMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_tuple("PeekMaxMut")
-         .field(&self.heap.0[self.max_index])
+         .field(&**self)
          .finish()
     }
 }
@@ -1034,5 +1034,12 @@ mod tests {
         assert_eq!(2, h.push_pop_max(0));
         assert_eq!(Some(&0), h.peek_min());
         assert_eq!(Some(&1), h.peek_max());
+    }
+
+    #[test]
+    fn peek_mut_format() {
+        let mut h = MinMaxHeap::from(vec![1, 2, 3]);
+        assert_eq!("PeekMinMut(1)", format!("{:?}", h.peek_min_mut().unwrap()));
+        assert_eq!("PeekMaxMut(3)", format!("{:?}", h.peek_max_mut().unwrap()));
     }
 }


### PR DESCRIPTION
Allows the compiler to infer that the core heap methods can't panic due to bounds checks. (`push_pop_{max, min}()` and `replace_{max, min}()` still need to be replaced with versions using `peek_{min, max}_mut()` to avoid bounds checks. I implemented this in my previous PR: #8.) This significantly improves performance, as the compiler avoids branch instructions, outputs less code, and is able to inline the functions completely.

Before:
```
test pop_max_seq ... bench:      69,594 ns/iter (+/- 9,316)
test pop_min_seq ... bench:      86,875 ns/iter (+/- 2,483)
test push_seq    ... bench:      22,185 ns/iter (+/- 1,641)
```
After:
```
test pop_max_seq ... bench:      64,055 ns/iter (+/- 5,473)
test pop_min_seq ... bench:      86,439 ns/iter (+/- 2,132)
test push_seq    ... bench:      15,420 ns/iter (+/- 2,914)
```