### PR TITLE
Improve spec heap used in random testing

### DIFF
--- a/tests/fake_heap.rs
+++ b/tests/fake_heap.rs
@@ -1,43 +1,76 @@
-#[derive(Debug, PartialEq, Eq)]
-pub struct FakeHeap<T>(Vec<T>);
+use std::collections::btree_map::BTreeMap;
 
-impl<T: Ord> FakeHeap<T> {
+#[derive(Debug, Eq, PartialEq)]
+pub struct FakeHeap<T> {
+    tree: BTreeMap<T, usize>,
+    len: usize,
+}
+
+impl<T: Clone + Ord> FakeHeap<T> {
     pub fn new() -> Self {
-        FakeHeap(Vec::new())
+        Self {
+            tree: BTreeMap::new(),
+            len: 0,
+        }
     }
 
-    fn find_min(&self) -> Option<usize> {
-        self.0.iter().enumerate().min_by_key(|p| p.1).map(|p| p.0)
+    pub fn len(&self) -> usize {
+        self.len
     }
 
-    fn find_max(&self) -> Option<usize> {
-        self.0.iter().enumerate().max_by_key(|p| p.1).map(|p| p.0)
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     pub fn push(&mut self, element: T) {
-        self.0.push(element);
+        if let Some(found) = self.tree.get_mut(&element) {
+            *found += 1;
+        } else {
+            self.tree.insert(element, 0);
+        }
+
+        self.len += 1;
     }
 
     pub fn peek_min(&self) -> Option<&T> {
-        self.find_min().map(|i| &self.0[i])
+        self.tree.range(..).next().map(|p| p.0)
     }
 
     pub fn peek_max(&self) -> Option<&T> {
-        self.find_max().map(|i| &self.0[i])
-    }
-
-    fn pop_index(&mut self, i: usize) -> T {
-        let last = self.0.len() - 1;
-        self.0.swap(i, last);
-        self.0.pop().unwrap()
+        self.tree.range(..).next_back().map(|p| p.0)
     }
 
     pub fn pop_min(&mut self) -> Option<T> {
-        self.find_min().map(|i| self.pop_index(i))
+        if let Some((elem, count)) = self.tree.range_mut(..).next() {
+            let elem = elem.clone();
+            if let Some(pred) = count.checked_sub(1) {
+                *count = pred;
+            } else {
+                self.tree.remove(&elem); 
+            }
+
+            self.len -= 1;
+            Some(elem)
+        } else {
+            None
+        }
     }
 
     pub fn pop_max(&mut self) -> Option<T> {
-        self.find_max().map(|i| self.pop_index(i))
+        if let Some((elem, count)) = self.tree.range_mut(..).next_back() {
+            let elem = elem.clone();
+            if let Some(pred) = count.checked_sub(1) {
+                *count = pred;
+            } else {
+                self.tree.remove(&elem); 
+            }
+
+            self.len -= 1;
+            Some(elem)
+        } else {
+            None
+        }
     }
 
     pub fn push_pop_min(&mut self, element: T) -> T {
@@ -62,4 +95,3 @@ impl<T: Ord> FakeHeap<T> {
         result
     }
 }
-

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -97,7 +97,11 @@ impl<T: Clone + Ord> Tester<T> {
         let f  = &mut self.fake;
 
         match cmd {
-            Push       => r.push(e1) == f.push(e2),
+            Push       => {
+                r.push(e1);
+                f.push(e2);
+                true
+            }
             PopMin     => r.pop_min() == f.pop_min(),
             PopMax     => r.pop_max() == f.pop_max(),
             PushPopMin => r.push_pop_min(e1) == f.push_pop_min(e2),

--- a/tests/random.rs
+++ b/tests/random.rs
@@ -79,13 +79,16 @@ impl<T: Clone + Ord> Tester<T> {
     }
 
     fn check_script(&mut self, script: &Script<T>) -> bool {
-        script.0.iter().all(|&(cmd, ref elt)|
-            self.check_command(cmd, elt) && self.check_extrema())
+        script.0
+            .iter()
+            .all(|&(cmd, ref elt)| self.do_checks(cmd, elt))
     }
 
-    fn check_extrema(&self) -> bool {
-        self.real.peek_min() == self.fake.peek_min() &&
-            self.real.peek_max() == self.fake.peek_max()
+    fn do_checks(&mut self, cmd: Command, elt: &T) -> bool {
+        self.check_command(cmd, elt)
+            && self.real.len() == self.fake.len()
+            && self.real.peek_min() == self.fake.peek_min()
+            && self.real.peek_max() == self.fake.peek_max()
     }
 
     fn check_command(&mut self, cmd: Command, elt: &T) -> bool {

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,0 +1,36 @@
+use min_max_heap::MinMaxHeap;
+
+#[test]
+fn random_20211219() {
+    let mut h = MinMaxHeap::<usize>::new();
+
+    // 0
+    assert_eq!( h.replace_max(0), None );
+    assert_eq!( h.len(), 1 );
+
+    // 0 1
+    h.push(1);
+    assert_eq!( h.len(), 2 );
+    assert_eq!( h.peek_min(), Some(&0) );
+    assert_eq!( h.peek_max(), Some(&1) );
+
+    // 0 0 1
+    h.push(0);
+    assert_eq!( h.len(), 3 );
+    assert_eq!( h.peek_min(), Some(&0) );
+    assert_eq!( h.peek_max(), Some(&1) );
+
+    // 0 0 1 1
+    h.push(1);
+    assert_eq!( h.len(), 4 );
+    assert_eq!( h.peek_min(), Some(&0) );
+    assert_eq!( h.peek_max(), Some(&1) );
+
+    // 0 0 0 1
+    assert_eq!( h.replace_max(0), Some(1) );
+    assert_eq!( h.len(), 4 );
+    assert_eq!( h.peek_min(), Some(&0) );
+    assert_eq!( h.peek_max(), Some(&1) );
+
+    assert_eq!( h.into_vec_asc(), vec![0, 0, 0, 1] );
+}


### PR DESCRIPTION
In particular, we use a B-tree from the standard library rather than a vector. This makes operations log time rather than linear time, which could enable running larger random tests.
